### PR TITLE
Add PyAv explicitly to pyproject.toml and remove .close() function usage

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -33,6 +33,7 @@ dependencies = [
     "tqdm>=4.64.0",
     "psutil>=5.9.0",
     "ray[data]>=2.8.0",
+    "av>=14.0.0",
 ]
 
 [project.optional-dependencies]

--- a/robodm/trajectory.py
+++ b/robodm/trajectory.py
@@ -346,7 +346,6 @@ class CodecConfig:
             cc.pix_fmt = pix_fmt
             cc.time_base = Fraction(1, 30)
             cc.open(strict=True)
-            cc.close()
             return True
         except Exception:
             return False


### PR DESCRIPTION
### Summary :memo:
As discussed in #32, PyAv no longer supports the `CodecContext.close()` function. This was deprecated as the new versions automatically handle codex context lifecycles when they go out of scope, in line with modifications to the FFmpeg API. Furthermore, the issue brings to our attention that we have not explicitly added PyAv into our project dependencies, which can raise issues. 

### Details
_Describe more what you did on changes._
1. Added PyAv (version 14.0.0 and above) to `pyproject.toml`
2. Removed instance of `CodecContext.close()`. 

### Checks
- [ ] Closed #32 
- [ ] Stakeholder approval 
- [ ] Merged PR
